### PR TITLE
Apply various cleanup tasks

### DIFF
--- a/program.md
+++ b/program.md
@@ -27,19 +27,6 @@ You are an intelligent assistant responsible for generating personalized exercis
     - Neck, Shoulders, Chest, Arms, Abdomen, Back, Glutes, Upper Legs, Lower Legs
   - **Cardio Preferences:** This parameter is included only if the "Exercise Modalities" include cardio. It specifies the user's preferred type of cardio exercises and should be used to guide the inclusion of suitable cardio activities in the program.
 
-- The following parameters guide the personalization of exercise or recovery programs:
-
-  - **Diagnosis:** The specific condition diagnosed for the user (e.g., "neck strain").
-  - **Painful Areas:** Areas of the body identified as painful (e.g., ["neck", "left shoulder"]).
-  - **Avoid Activities:** Specific activities to avoid due to potential aggravation (e.g., ["running", "lifting weights"]).
-  - **Recovery Goals:** Goals the user wishes to achieve, such as ["reduce pain", "improve mobility"].
-  - **Time Frame:** The recommended duration for the program (e.g., "4-6 weeks"), after which reassessment is required.
-  - **Follow-Up Questions:** Questions aimed at refining the diagnosis (e.g., ["Do you have pain in your neck?", "Do you have pain in your shoulder?"]).
-  - **Selected Question:** The specific follow-up question addressed in the current session.
-  - **Program Type:** Indicates whether the program is "exercise" or "recovery".
-  - **Target Areas:** Focused body areas targeted during exercise (applicable only for "exercise" programs, not applicable for recovery programs). These are the areas the user has selected for their workout program. Exercises should be based on these areas. The target areas can contain different body groups or parts. Potential values include:
-  - Full Body, Upper Body, Lower Body
-  - Neck, Shoulders, Chest, Arms, Abdomen, Back, Glutes, Upper Legs, Lower Legs
 
 - **UserInfo:** This data provides additional context about the user's preferences and physical condition, allowing for further personalization. The key fields include:
 

--- a/public/data/exercises/json/quads.json
+++ b/public/data/exercises/json/quads.json
@@ -1570,7 +1570,7 @@
         "Walk your feet out a few steps while keeping your upper body flat against the wall.  Your legs should be straight with a slight bend in your knees and your feet should be just inside shoulder width apart.",
         "Now Lift your right foot from the floor and extend your leg out in front of you. This is the starting position.",
         "While bending at the knee and sliding your torso downward (still pressed against the wall) lower your buttocks towards the ground.",
-        "Squat down until your left thigh is parallel to the floor. Keep your right leg extended to keep your foot from touching the the ground.",
+        "Squat down until your left thigh is parallel to the floor. Keep your right leg extended to keep your foot from touching the ground.",
         "Pause for a moment and press through your heel to push yourself back to the starting position.",
         "Repeat this movement for desired reps and then repeat using your right leg.",
         "Keep your torso as still as possible throughout the movement with your back straight and constantly pressed against the wall.",
@@ -5173,7 +5173,7 @@
       "tips": [
         "Never stretch to the point of pain or discomfort which causes you to hold your breath. Holding the breath increases global tension and will only work against the effects of the stretch at hand.",
         "Don’t allow the lower back to arch, you should feel a stretch through the front of your quads and tension through the abs.",
-        "Squeeze the glute on the the plant leg to increase the stretch on the hip flexor. Think about trying to roll your pelvis underneath or “pull your zipper towards your forehead”.",
+        "Squeeze the glute on the plant leg to increase the stretch on the hip flexor. Think about trying to roll your pelvis underneath or “pull your zipper towards your forehead”.",
         "Remember, hips and shoulders rock forward together, you shouldn’t break at the spine."
       ],
       "contraindications": [

--- a/src/app/helpers/__tests__/exercise-prompt.test.ts
+++ b/src/app/helpers/__tests__/exercise-prompt.test.ts
@@ -621,20 +621,6 @@ describe('Equipment type coverage tests', () => {
     expect(result.exercisesPrompt).toMatch(/Kettle(bell)?/i);
   });
   
-  // Test medicine ball equipment - mark as skip if no Medicine Ball exercises found
-  test.skip('Medicine ball equipment should include medicine ball exercises', async () => {
-    const userInfo = createUserInfo({
-      exerciseModalities: 'Strength',
-      exerciseEnvironments: 'Custom',
-      equipment: ['Medicine Ball'], // Only medicine ball
-      targetAreas: ['Core', 'Chest', 'Full Body'],
-    });
-    
-    const result = await prepareExercisesPrompt(userInfo, undefined, true);
-    
-    // Should include medicine ball exercises
-    expect(result.exercisesPrompt).toMatch(/Medicine Ball/i);
-  });
   
   // Test combination of multiple specialty equipment - include TRX and Bands only, since those are present in the database
   test('Combination of specialty equipment should include exercises for all selected equipment', async () => {

--- a/src/app/program/page.tsx
+++ b/src/app/program/page.tsx
@@ -62,21 +62,14 @@ export default function ProgramPage() {
     }
   }, [isLoading, selectedProgram, programStatus, t, authLoading]);
 
-  // Update page title when program loads
+  // Update page title when program data changes
   useEffect(() => {
-    if (selectedProgram?.title && typeof document !== 'undefined') {
-      document.title = `${selectedProgram.title} | bodAI`;
-    } else if (typeof document !== 'undefined') {
-      document.title = t('program.pageTitle');
-    }
-  }, [selectedProgram, t]);
-
-  // Update page title with program title
-  useEffect(() => {
-    if (selectedProgram?.title) {
-      document.title = `${selectedProgram.title} | bodAI`;
-    } else {
-      document.title = t('program.defaultPageTitle');
+    if (typeof document !== 'undefined') {
+      if (selectedProgram?.title) {
+        document.title = `${selectedProgram.title} | bodAI`;
+      } else {
+        document.title = t('program.defaultPageTitle');
+      }
     }
   }, [selectedProgram?.title, t]);
 


### PR DESCRIPTION
## Summary
- fix duplicated word typos in quads exercise data
- consolidate page title effect on program page
- remove duplicate parameter list from documentation
- delete unused medicine ball test

## Testing
- `yarn test` *(fails: Error when performing the request to https://registry.yarnpkg.com/yarn/-/yarn-1.22.22.tgz)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6839f4035d3483329e38fe62dc3286e4