### PR TITLE
Implement landing hero overlay for unauthenticated users

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "react-phone-number-input": "^3.4.12",
     "react-spring": "^8.0.27",
     "react-spring-bottom-sheet": "3.5.0-alpha.0",
+    "framer-motion": "^10.16.1",
     "resend": "^4.4.0",
     "server-only": "^0.0.1"
   },

--- a/src/app/components/3d/HumanViewer.tsx
+++ b/src/app/components/3d/HumanViewer.tsx
@@ -16,16 +16,20 @@ import { useApp } from '@/app/context/AppContext';
 import { useUser } from '@/app/context/UserContext';
 import { logAnalyticsEvent } from '@/app/utils/analytics';
 
+type ViewerMode = 'full' | 'diagnose' | 'questionnaire';
+
 interface HumanViewerProps {
-  gender: Gender;
+  gender?: Gender;
   onGenderChange?: (gender: Gender) => void;
   shouldResetModel?: boolean;
+  mode?: ViewerMode;
 }
 
 export default function HumanViewer({
-  gender,
+  gender = 'male',
   onGenderChange,
   shouldResetModel = false,
+  mode = 'full',
 }: HumanViewerProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const {

--- a/src/app/components/ui/LandingHero.tsx
+++ b/src/app/components/ui/LandingHero.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { useState } from 'react'
+import { motion } from 'framer-motion'
+import PartnerLogos from '@/components/PartnerLogos'
+
+export type ViewerMode = 'full' | 'diagnose' | 'questionnaire'
+
+function ExamplePlan() {
+  const [open, setOpen] = useState(false)
+  return (
+    <div className="mt-6 w-full max-w-md mx-auto">
+      <button
+        aria-label="Toggle example plan"
+        onClick={() => setOpen(!open)}
+        className="w-full flex items-center justify-between bg-gray-800/50 rounded-md px-4 py-2 text-white"
+      >
+        <span>example plan</span>
+        <span>{open ? '−' : '+'}</span>
+      </button>
+      {open && (
+        <div className="mt-2 space-y-1 text-left text-sm text-gray-200">
+          <p>day 1: mobility &amp; stretching</p>
+          <p>day 2: strength &amp; stability</p>
+          <p>day 3: active recovery</p>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default function LandingHero({ onSelect }: { onSelect: (m: ViewerMode) => void }) {
+  return (
+    <div className="absolute inset-0 flex flex-col items-center justify-center text-center px-4 bg-gradient-to-b from-[#0d1117] to-[#1a1f24]">
+      <video
+        src="/videos/hero-shoulder-demo.mp4"
+        className="rounded-lg w-full max-w-lg mx-auto"
+        autoPlay
+        muted
+        loop
+        playsInline
+        style={{ maxHeight: '40vh' }}
+      >
+        <track kind="captions" />
+      </video>
+      <h1 className="mt-6 text-3xl font-bold text-white">relieve pain, rebuild strength</h1>
+      <p className="text-gray-300 mb-6">custom rehab plan in under 2 minutes</p>
+      <div className="flex gap-4 mb-4">
+        <motion.button
+          id="btn-diagnose"
+          whileHover={{ scale: 1.05 }}
+          whileTap={{ scale: 0.95 }}
+          onClick={() => onSelect('diagnose')}
+          className="px-4 py-2 bg-indigo-600 text-white rounded-md"
+          aria-label="i have pain"
+        >
+          i have pain
+        </motion.button>
+        <motion.button
+          id="btn-workout"
+          whileHover={{ scale: 1.05 }}
+          whileTap={{ scale: 0.95 }}
+          onClick={() => onSelect('questionnaire')}
+          className="px-4 py-2 border border-white text-white rounded-md"
+          aria-label="just need a workout"
+        >
+          just need a workout
+        </motion.button>
+      </div>
+      <PartnerLogos />
+      <div className="mt-4 flex items-center gap-2 text-sm text-white">
+        <span className="text-yellow-400">★★★★★</span>
+        <span>4.9</span>
+        <a
+          href="https://g.page/r/GREPLACE"
+          className="underline"
+          aria-label="138 reviews"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          138 reviews
+        </a>
+      </div>
+      <ExamplePlan />
+    </div>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,6 +12,7 @@ import { useSearchParams, useRouter } from 'next/navigation';
 import { IntentionQuestion } from './components/ui/IntentionQuestion';
 import { ErrorDisplay } from './components/ui/ErrorDisplay';
 import { useTranslation } from './i18n';
+import LandingHero, { ViewerMode } from './components/ui/LandingHero';
 
 // Create a separate component for search params functionality
 function HomeContent() {
@@ -32,6 +33,8 @@ function HomeContent() {
   const [gender, setGender] = useState<Gender>(genderParam || 'male');
   const [intentionSelected, setIntentionSelected] = useState(false);
   const [shouldResetModel, setShouldResetModel] = useState(false);
+  const [showHero, setShowHero] = useState(!user && newParam !== 'true');
+  const [viewerMode, setViewerMode] = useState<ViewerMode>('full');
 
   // Set page title
   useEffect(() => {
@@ -88,6 +91,11 @@ function HomeContent() {
     [setIntention]
   );
 
+  const handleHeroSelect = useCallback((mode: ViewerMode) => {
+    setViewerMode(mode);
+    setShowHero(false);
+  }, []);
+
   // Show auth form if user is not logged in and not skipping auth
   // OR if we have pending questionnaire data and user is not logged in
   useEffect(() => {
@@ -109,6 +117,15 @@ function HomeContent() {
       setShowAuthForm(false);
     }
   }, [user, authLoading, skipAuth, pendingQuestionnaire, showAuthForm]);
+
+  // Show landing hero when user is not authenticated on the main page
+  useEffect(() => {
+    if (!user && newParam !== 'true' && !showAuthForm) {
+      setShowHero(true);
+    } else {
+      setShowHero(false);
+    }
+  }, [user, newParam, showAuthForm]);
 
   // Clear the pendingQuestionnaire flag in localStorage when user logs in
   useEffect(() => {
@@ -136,11 +153,14 @@ function HomeContent() {
       {/* Only render HumanViewer when not showing IntentionQuestion and not showing QuestionnaireAuthForm */}
       {!(newParam === 'true' && !intentionSelected) &&
         !(showAuthForm && pendingQuestionnaire) && (
-          <HumanViewer
-            gender={gender}
-            onGenderChange={handleGenderChange}
-            shouldResetModel={shouldResetModel}
-          />
+          <div className={showHero ? 'invisible h-0' : undefined}>
+            <HumanViewer
+              gender={gender}
+              onGenderChange={handleGenderChange}
+              shouldResetModel={shouldResetModel}
+              mode={viewerMode}
+            />
+          </div>
         )}
 
       {/* Conditionally overlay the auth form */}
@@ -160,6 +180,8 @@ function HomeContent() {
           }}
         />
       )}
+
+      {showHero && <LandingHero onSelect={handleHeroSelect} />}
     </div>
   );
 }

--- a/src/components/PartnerLogos.tsx
+++ b/src/components/PartnerLogos.tsx
@@ -1,0 +1,1 @@
+export { PartnerLogos as default } from '../app/components/ui/PartnerLogos';


### PR DESCRIPTION
## Summary
- restore original `Home` page logic
- create `LandingHero` component with video hero and CTA buttons
- overlay hero when user is not authenticated

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a04039bdc8332be8b02b6641a3e24