### PR TITLE
Add global BioDigital SDK loader

### DIFF
--- a/src/app/hooks/useHumanAPI.ts
+++ b/src/app/hooks/useHumanAPI.ts
@@ -15,6 +15,7 @@ import {
   getGenderedId,
 } from '../utils/anatomyHelpers';
 import { ProgramIntention, useApp } from '../context/AppContext';
+import { loadHumanSdk } from '../../utils/loadHumanSdk';
 
 interface CameraPosition {
   position: {
@@ -146,23 +147,11 @@ export function useHumanAPI({
   // Function to check if camera has moved
 
   useEffect(() => {
-    let script: HTMLScriptElement | null = null;
+    if (typeof window === 'undefined') return;
+
     let isInitialized = false;
 
-    const initializeViewer = () => {
-      if (!window.HumanAPI) {
-        script = document.createElement('script');
-        script.src =
-          'https://developer.biodigital.com/builds/api/human-api-3.0.0.min.js';
-        script.async = true;
-        script.onload = setupHumanAPI;
-        document.body.appendChild(script);
-      } else {
-        setupHumanAPI();
-      }
-    };
-
-    const setupHumanAPI = () => {
+    const setupHumanAPI = async () => {
       try {
         // Clean up existing instance if it exists
         if (humanRef.current) {
@@ -180,7 +169,8 @@ export function useHumanAPI({
           ? { x: 0, y: 0, z: -50 } // More zoomed out for mobile
           : { x: 0, y: 0, z: -25 };
 
-        const human = new window.HumanAPI(elementId, {
+        const HumanAPI = await loadHumanSdk();
+        const human = new HumanAPI(elementId, {
           camera: {
             position: cameraPosition,
           },
@@ -219,13 +209,10 @@ export function useHumanAPI({
       }
     };
 
-    initializeViewer();
+    setupHumanAPI();
 
     return () => {
       if (!isInitialized) {
-        if (script) {
-          document.body.removeChild(script);
-        }
         setIsReady(false);
         humanRef.current = null;
       }

--- a/src/utils/loadHumanSdk.ts
+++ b/src/utils/loadHumanSdk.ts
@@ -1,0 +1,46 @@
+let sdkPromise: Promise<typeof window.HumanAPI> | null = null;
+
+export async function loadHumanSdk(): Promise<typeof window.HumanAPI> {
+  if (typeof window === 'undefined') {
+    return Promise.reject(new Error('window is undefined'));
+  }
+
+  if (window.HumanAPI) {
+    return Promise.resolve(window.HumanAPI);
+  }
+
+  if (sdkPromise) {
+    return sdkPromise;
+  }
+
+  sdkPromise = new Promise((resolve, reject) => {
+    let script = document.getElementById('biodigital-sdk') as HTMLScriptElement | null;
+
+    const handleLoad = () => {
+      if (window.HumanAPI) {
+        resolve(window.HumanAPI);
+      } else {
+        reject(new Error('HumanAPI failed to load'));
+      }
+    };
+
+    const handleError = () => {
+      reject(new Error('Failed to load BioDigital SDK'));
+    };
+
+    if (script) {
+      script.addEventListener('load', handleLoad);
+      script.addEventListener('error', handleError);
+    } else {
+      script = document.createElement('script');
+      script.id = 'biodigital-sdk';
+      script.src = 'https://developer.biodigital.com/builds/api/human-api-3.0.0.min.js';
+      script.async = true;
+      script.addEventListener('load', handleLoad);
+      script.addEventListener('error', handleError);
+      document.body.appendChild(script);
+    }
+  });
+
+  return sdkPromise;
+}


### PR DESCRIPTION
## Summary
- introduce `loadHumanSdk` utility for singleton script loading
- refactor `useHumanAPI` to use new loader and clean up script logic

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'jest' and 'node')*

------
https://chatgpt.com/codex/tasks/task_e_687a2c28b0208332a42c7d8393642e8e