### PR TITLE
fix: confirm subscription on success

### DIFF
--- a/src/app/api/subscribe/confirm/route.ts
+++ b/src/app/api/subscribe/confirm/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+import { stripe } from '@/app/lib/stripe';
+import { adminDb } from '@/app/firebase/admin';
+
+export const runtime = 'nodejs';
+
+export async function POST(request: Request) {
+  try {
+    const { sessionId, uid } = await request.json();
+    if (!sessionId || !uid) {
+      return NextResponse.json({ error: 'Missing sessionId or uid' }, { status: 400 });
+    }
+
+    const session = await stripe.checkout.sessions.retrieve(sessionId, {
+      expand: ['subscription']
+    });
+    const subscription = session.subscription as any;
+    const status = subscription?.status as string | undefined;
+    const customerId = session.customer as string | undefined;
+
+    if (subscription && customerId && status) {
+      await adminDb.collection('users').doc(uid).set(
+        {
+          stripeCustomerId: customerId,
+          stripeSubscriptionId: subscription.id,
+          subscriptionStatus: status,
+          isSubscriber: status === 'active' || status === 'trialing'
+        },
+        { merge: true }
+      );
+    }
+
+    return NextResponse.json({ status: status || session.status });
+  } catch (error) {
+    console.error('Subscription confirm error', error);
+    return NextResponse.json({ error: 'Failed to confirm session' }, { status: 500 });
+  }
+}

--- a/src/app/subscribe/success/page.tsx
+++ b/src/app/subscribe/success/page.tsx
@@ -1,20 +1,37 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useAuth } from '@/app/context/AuthContext';
 import { db } from '@/app/firebase/config';
-import { doc, getDoc } from 'firebase/firestore';
+import { doc, getDocFromServer } from 'firebase/firestore';
+import { useLoader } from '@/app/context/LoaderContext';
 
 export default function SubscribeSuccessPage() {
   const router = useRouter();
-  const { user, loading } = useAuth();
+  const searchParams = useSearchParams();
+  const sessionId = searchParams.get('session_id');
+  const { user, loading, updateUserProfile } = useAuth();
+  const { setIsLoading: showGlobalLoader } = useLoader();
   const [statusText, setStatusText] = useState('Finalizing your subscription…');
+
+  useEffect(() => {
+    showGlobalLoader(true, statusText);
+  }, [statusText, showGlobalLoader]);
 
   useEffect(() => {
     // Wait for auth to settle before deciding anything
     if (loading) return;
     if (!user?.uid) return; // don't kick to login; let user arrive after redirect
+
+    if (sessionId) {
+      // As a fallback if webhook is delayed/missing, confirm session on server
+      fetch('/api/subscribe/confirm', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId, uid: user.uid }),
+      }).catch(() => {});
+    }
 
     let cancelled = false;
     let attempts = 0;
@@ -22,10 +39,23 @@ export default function SubscribeSuccessPage() {
     const check = async () => {
       attempts += 1;
       try {
-        const snap = await getDoc(doc(db, 'users', user.uid));
+        // Force a server read to ensure we get the latest subscription data
+        const snap = await getDocFromServer(doc(db, 'users', user.uid));
         const data = snap.exists() ? (snap.data() as any) : null;
-        const active = data?.isSubscriber === true || data?.subscriptionStatus === 'active' || data?.subscriptionStatus === 'trialing';
+        const active =
+          data?.isSubscriber === true ||
+          data?.subscriptionStatus === 'active' ||
+          data?.subscriptionStatus === 'trialing';
         if (active && !cancelled) {
+          setStatusText('Loading your account…');
+          // Ensure auth context sees subscription immediately
+          await updateUserProfile({
+            isSubscriber: true,
+            subscriptionStatus: data?.subscriptionStatus,
+            stripeCustomerId: data?.stripeCustomerId,
+            stripeSubscriptionId: data?.stripeSubscriptionId,
+            currentPeriodEnd: data?.currentPeriodEnd,
+          });
           router.replace('/program/feedback');
           return;
         }
@@ -46,7 +76,7 @@ export default function SubscribeSuccessPage() {
       cancelled = true;
       clearTimeout(t);
     };
-  }, [user, loading, router]);
+  }, [user, loading, router, sessionId, updateUserProfile]);
 
   return (
     <div className="min-h-screen bg-gray-900 text-white flex items-center justify-center p-6">


### PR DESCRIPTION
## Summary
- confirm Stripe session on success redirect and persist subscription data
- refresh auth profile before redirecting so subscription is recognized immediately
- show global loader while finalizing subscription and before routing to feedback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68987bd54f9c8332a616cd5d01cf71b2