### PR TITLE
Confirm Stripe checkout session on success redirect

### DIFF
--- a/src/app/api/subscribe/confirm/route.ts
+++ b/src/app/api/subscribe/confirm/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server';
+import { stripe } from '@/app/lib/stripe';
+import { adminDb } from '@/app/firebase/admin';
+
+export const runtime = 'nodejs';
+
+export async function POST(request: Request) {
+  try {
+    const { session_id, uid } = await request.json();
+    if (!session_id || !uid) {
+      return NextResponse.json({ error: 'Missing session or uid' }, { status: 400 });
+    }
+
+    const session = await stripe.checkout.sessions.retrieve(session_id, { expand: ['subscription'] });
+    const sessionUid = (session.metadata as any)?.uid;
+    if (sessionUid !== uid) {
+      return NextResponse.json({ error: 'UID mismatch' }, { status: 403 });
+    }
+
+    const subscription: any = session.subscription;
+    if (!subscription) {
+      return NextResponse.json({ error: 'No subscription found' }, { status: 400 });
+    }
+
+    const status = subscription.status as string;
+    const currentPeriodEnd = subscription.current_period_end
+      ? new Date(subscription.current_period_end * 1000).toISOString()
+      : undefined;
+
+    await adminDb
+      .collection('users')
+      .doc(uid)
+      .set(
+        {
+          stripeCustomerId: session.customer,
+          stripeSubscriptionId: subscription.id,
+          subscriptionStatus: status,
+          isSubscriber: status === 'active' || status === 'trialing',
+          ...(currentPeriodEnd ? { currentPeriodEnd } : {}),
+        },
+        { merge: true }
+      );
+
+    return NextResponse.json({ ok: true, status });
+  } catch (error) {
+    console.error('Confirm checkout session error', error);
+    return NextResponse.json({ error: 'Failed to confirm session' }, { status: 500 });
+  }
+}
+

--- a/src/app/context/AuthContext.tsx
+++ b/src/app/context/AuthContext.tsx
@@ -30,6 +30,7 @@ interface AuthContextType {
   createUserDoc: () => Promise<void>;
   updateUserProfile: (profileData: Partial<UserProfile>) => Promise<void>;
   getUserProfile: () => Promise<UserProfile | null>;
+  refreshUserProfile: () => Promise<void>;
   deleteUserDoc: (uid: string) => Promise<void>;
   deleteUserAccount: () => Promise<boolean>;
   deleteProgram: (programId: string) => Promise<boolean>;
@@ -249,6 +250,19 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       console.error('Error getting user profile:', error);
       handleAuthError(error, t('authContext.failedToGetUserProfile'), false);
       return null;
+    }
+  };
+
+  const refreshUserProfile = async (): Promise<void> => {
+    if (!user) return;
+
+    try {
+      const profileData = await fetchUserProfile(user.uid);
+      setUser((prev) =>
+        prev ? ({ ...prev, profile: profileData || prev.profile } as ExtendedUser) : prev
+      );
+    } catch (error) {
+      console.error('Error refreshing user profile:', error);
     }
   };
 
@@ -559,6 +573,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         createUserDoc,
         updateUserProfile,
         getUserProfile,
+        refreshUserProfile,
         deleteUserDoc,
         deleteUserAccount,
         deleteProgram,

--- a/src/app/subscribe/success/page.tsx
+++ b/src/app/subscribe/success/page.tsx
@@ -1,62 +1,52 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useAuth } from '@/app/context/AuthContext';
-import { db } from '@/app/firebase/config';
-import { doc, getDocFromServer } from 'firebase/firestore';
+import { useLoader } from '@/app/context/LoaderContext';
 
 export default function SubscribeSuccessPage() {
   const router = useRouter();
-  const { user, loading } = useAuth();
-  const [statusText, setStatusText] = useState('Finalizing your subscription…');
+  const searchParams = useSearchParams();
+  const sessionId = searchParams.get('session_id');
+  const { user, loading, refreshUserProfile } = useAuth();
+  const { showLoader, hideLoader } = useLoader();
 
   useEffect(() => {
-    // Wait for auth to settle before deciding anything
     if (loading) return;
-    if (!user?.uid) return; // don't kick to login; let user arrive after redirect
+    if (!user?.uid || !sessionId) return;
 
     let cancelled = false;
-    let attempts = 0;
 
-    const check = async () => {
-      attempts += 1;
+    const finalize = async () => {
+      showLoader('Finalizing your subscription…');
       try {
-        // Force a server read to ensure we get the latest subscription data
-        const snap = await getDocFromServer(doc(db, 'users', user.uid));
-        const data = snap.exists() ? (snap.data() as any) : null;
-        const active = data?.isSubscriber === true || data?.subscriptionStatus === 'active' || data?.subscriptionStatus === 'trialing';
-        if (active && !cancelled) {
+        await fetch('/api/subscribe/confirm', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ session_id: sessionId, uid: user.uid }),
+        });
+        await refreshUserProfile();
+        if (!cancelled) {
           router.replace('/program/feedback');
-          return;
         }
-      } catch {}
-
-      if (!cancelled) {
-        if (attempts < 7) {
-          setTimeout(check, 1500);
-        } else {
-          setStatusText('Subscription recorded, loading your account…');
+      } catch (err) {
+        console.error('Subscription confirmation failed', err);
+        if (!cancelled) {
           router.replace('/program');
         }
+      } finally {
+        hideLoader();
       }
     };
 
-    const t = setTimeout(check, 800);
+    finalize();
+
     return () => {
       cancelled = true;
-      clearTimeout(t);
     };
-  }, [user, loading, router]);
+  }, [loading, user, sessionId, router, refreshUserProfile, showLoader, hideLoader]);
 
-  return (
-    <div className="min-h-screen bg-gray-900 text-white flex items-center justify-center p-6">
-      <div className="text-center">
-        <div className="text-2xl font-semibold mb-2">Thanks for subscribing!</div>
-        <div className="text-gray-300">{statusText}</div>
-      </div>
-    </div>
-  );
+  return null;
 }
-
 


### PR DESCRIPTION
## Summary
- Add API route to verify Stripe checkout session and persist subscription info
- Expose `refreshUserProfile` in auth context to reload profile data
- Finalize subscription on success page, refresh user and redirect with global loader

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689898070a40833295bbd6464974efc1