### PR TITLE
Wrap subscribe success page in Suspense

### DIFF
--- a/src/app/subscribe/success/page.tsx
+++ b/src/app/subscribe/success/page.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { useEffect } from 'react';
+import { Suspense, useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useAuth } from '@/app/context/AuthContext';
 import { useLoader } from '@/app/context/LoaderContext';
 
-export default function SubscribeSuccessPage() {
+function SubscribeSuccessContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const sessionId = searchParams.get('session_id');
@@ -48,5 +48,13 @@ export default function SubscribeSuccessPage() {
   }, [loading, user, sessionId, router, refreshUserProfile, showLoader, hideLoader]);
 
   return null;
+}
+
+export default function SubscribeSuccessPage() {
+  return (
+    <Suspense fallback={null}>
+      <SubscribeSuccessContent />
+    </Suspense>
+  );
 }
 


### PR DESCRIPTION
## Summary
- Wrap subscribe success page in `<Suspense>` and move search param logic to `SubscribeSuccessContent`

## Testing
- `yarn lint`
- `yarn test`
- `yarn build` *(fails: The OPENAI_API_KEY environment variable is missing or empty)*

------
https://chatgpt.com/codex/tasks/task_e_6898a3ec8db48332a6a1f8394d0ae895